### PR TITLE
feature: Introduce augmented working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 #### Docker alias
 
 ```sh
-alias goose='docker run --rm -it -v ${PWD}:/wd -v ~/.cache/goose-docker:/home/nonroot/.cache ghcr.io/antonagestam/goose:latest'
+alias goose='docker run --rm -it -v ${PWD}:/wd -v ~/.cache/goose-docker:/home/nonroot/.cache -e "GOOSE_AUGMENTED_CWD=${PWD}" ghcr.io/antonagestam/goose:latest'
 ```
 
 #### Via PyPI

--- a/src/goose/paths.py
+++ b/src/goose/paths.py
@@ -13,10 +13,17 @@ def _get_base_envs_path() -> Path:
     return _get_cache_home() / "goose"
 
 
+def _get_working_directory_hash() -> str:
+    if (virtual_cwd := os.environ.get("GOOSE_AUGMENTED_CWD", None)) is not None:
+        cwd = virtual_cwd.encode()
+    else:
+        cwd = bytes(Path(os.getcwd()).resolve())
+    return hashlib.sha256(cwd).hexdigest()
+
+
 def get_env_path() -> Path:
     base_path = _get_base_envs_path()
-    cwd = Path(os.getcwd()).resolve()
-    env_hash = hashlib.sha256(bytes(cwd))
-    env_path = base_path / env_hash.hexdigest()
+    cwd_hash = _get_working_directory_hash()
+    env_path = base_path / cwd_hash
     env_path.mkdir(exist_ok=True, parents=True)
     return env_path


### PR DESCRIPTION
This fixes an issue where the containerized invocation resulted in calculating the same environment path wherever it was invoked from. The environment var `GOOSE_AUGMENTED_CWD` is introduced and allows passing in the working directory in the host system to the containerized app so that it can calculate the same unique per-project environment path as the non-containerized app.